### PR TITLE
Upgrade SDK to version 1.8.0

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,5 +1,5 @@
 plugins {
-    id("com.microej.gradle.jse-library") version "1.7.0"
+    id("com.microej.gradle.jse-library") version "1.8.0"
 }
 
 group = "com.mycompany"


### PR DESCRIPTION
Bumps the MicroEJ SDK version used by this template to 1.8.0, as part of the SDK 6 1.8.0 release (M0090IDE-5603).

Generated by scripts/bump_sdk_version.py from the M0090_Gradle repository.

This cannot build green until the Gradle plugins 1.8.0 are published.